### PR TITLE
Using enum at Issue#status

### DIFF
--- a/backend/app/models/issue.rb
+++ b/backend/app/models/issue.rb
@@ -1,3 +1,7 @@
 class Issue < ApplicationRecord
 	validates :name, :body, :author_email, :status, presence: true
+  validates :author_email, format: {
+    with: /\A([^@\s]+)@((?:[-a-z0-9]+\.)+[a-z]{2,})\z/i
+  }
+  enum status: { open: 'open', closed: 'closed' }
 end

--- a/backend/test/controllers/issues_controller_test.rb
+++ b/backend/test/controllers/issues_controller_test.rb
@@ -1,21 +1,22 @@
 require 'test_helper'
 
 class IssuesControllerTest < ActionDispatch::IntegrationTest
-   fixtures :issues
+  fixtures :issues
 
-   def test_create_issue
-	    get "/issues"
-	    assert_equal 200, status
+  def test_create_issue
+    get "/issues"
+    assert_equal 200, status
 
-	    # post the issue
-	    post '/issues', params: { issue: {
-                                        name: issues(:issue1).name,
-                                        body: issues(:issue1).body,
-                                        author_email: issues(:issue1).author_email,
-                                        status: issues(:issue1).status
-                                      }
-                               }
-	    issue = JSON.parse(response.body)
-        assert_equal "issue1", issue['name']
-   end
+    # post the issue
+    post '/issues', params: { issue: {
+        name: issues(:issue1).name,
+        body: issues(:issue1).body,
+        author_email: issues(:issue1).author_email,
+        status: issues(:issue1).status
+      }
+    }
+
+    issue = JSON.parse(response.body)
+    assert_equal "issue1", issue['name']
+  end
 end

--- a/backend/test/controllers/issues_controller_test.rb
+++ b/backend/test/controllers/issues_controller_test.rb
@@ -3,20 +3,31 @@ require 'test_helper'
 class IssuesControllerTest < ActionDispatch::IntegrationTest
   fixtures :issues
 
-  def test_create_issue
+  setup do
+    @issue ||=  issues(:issue1)
+  end
+
+  def test_get_issues
     get "/issues"
     assert_equal 200, status
+  end
 
-    # post the issue
-    post '/issues', params: { issue: {
-        name: issues(:issue1).name,
-        body: issues(:issue1).body,
-        author_email: issues(:issue1).author_email,
-        status: issues(:issue1).status
+  def test_create_issue
+    post '/issues', params: {
+      issue: {
+        name: @issue.name,
+        body: @issue.body,
+        author_email: @issue.author_email,
+        status: @issue.status
       }
     }
 
     issue = JSON.parse(response.body)
     assert_equal "issue1", issue['name']
+  end
+
+  def test_show_issue
+    get issues_path(@issue.id)
+    assert_equal 200, status
   end
 end

--- a/backend/test/fixtures/issues.yml
+++ b/backend/test/fixtures/issues.yml
@@ -3,7 +3,7 @@
 issue1:
   name: issue1
   body: bla
-  author_email: sasha@bla
+  author_email: sasha@bla.com
   status: open
 
 two:

--- a/backend/test/models/issue_test.rb
+++ b/backend/test/models/issue_test.rb
@@ -1,7 +1,25 @@
 require 'test_helper'
 
 class IssueTest < ActiveSupport::TestCase
-  # test "the truth" do
-  #   assert true
-  # end
+
+  def test_invalid_status
+    issue_params = { name: 'foo', author_email: 'bar@foo.com', body: 'foo bar',
+      status: 'error' }
+
+    assert_raise(ArgumentError){ Issue.create(issue_params) }
+  end
+
+
+  def test_empty_status
+    issue_params = { name: 'foo', author_email: 'bar@foo.com', body: 'foo bar' }
+    issue = Issue.create(issue_params)
+    assert_equal false, issue.valid?
+  end
+
+  def test_empty_status
+    issue = Issue.create(name: 'foo', author_email: 'bar@foo.com',
+      body: 'foo bar', status: 'open')
+
+    assert_equal true, issue.persisted?
+  end
 end


### PR DESCRIPTION
# Main change

app/models/issue.rb

```ruby
class Issue < ApplicationRecord
  # ...
  enum status: { open: 'open', closed: 'closed' }
end
```
I have changed status to be an [enum](http://edgeapi.rubyonrails.org/classes/ActiveRecord/Enum.html), so it will allow us to query issues by status easily.

```ruby
Issue.open # returns all issues with open status
Issue.closed # returns all issues with closed status

issue = Issue.first
issue.open?  # true
issue.closed?  # false
``` 

# Extra change

Email validations

```ruby
class Issue < ApplicationRecord
  # ...
  validates :author_email, format: {
    with: /\A([^@\s]+)@((?:[-a-z0-9]+\.)+[a-z]{2,})\z/i
  }
end
```

# Final result

```ruby
class Issue < ApplicationRecord
  validates :name, :body, :author_email, :status, presence: true
  validates :author_email, format: {
    with: /\A([^@\s]+)@((?:[-a-z0-9]+\.)+[a-z]{2,})\z/i
  }
  enum status: { open: 'open', closed: 'closed' }
end
```